### PR TITLE
Support of 24V AC power supply relay

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -872,8 +872,6 @@ void OpenSprinkler::begin() {
 	detect_expanders();
 
 #else
-	// set power supply relay pin to output
-	pinMode(PIN_OSPI_POWER, OUTPUT);
 
 	// shift register setup
 	pinMode(PIN_SR_OE, OUTPUT);
@@ -896,6 +894,11 @@ void OpenSprinkler::begin() {
 		pinMode(PIN_SR_DATA, OUTPUT);
 	#endif
 
+#endif
+
+#if defined(OSPI)
+	// set power supply relay pin to output
+	pinMode(PIN_OSPI_POWER, OUTPUT);
 #endif
 
 	// Reset all stations
@@ -1197,9 +1200,8 @@ void OpenSprinkler::latch_apply_all_station_bits() {
 #endif
 
 /** Set power supply relay pin */
-void OpenSprinkler::set_power_supply_relay_pin()
-{
-	#if defined(OSPI) // if OSPI, use dynamically assigned pin_sr_data
+void OpenSprinkler::set_power_supply_relay_pin() {
+#if defined(OSPI) // if OSPI, use dynamically assigned pin_sr_data
 	// If any bit of any station is set, the relay is turned on
 	byte isActive = 0;
 	if (status.enabled) {
@@ -1208,7 +1210,7 @@ void OpenSprinkler::set_power_supply_relay_pin()
 		}
 	}
 	digitalWrite(PIN_OSPI_POWER, isActive ? 1 : 0);
-	#endif
+#endif
 }
 
 /** Apply all station bits

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -1204,6 +1204,7 @@ void OpenSprinkler::set_power_supply_relay_pin() {
 #if defined(OSPI) // if OSPI, use dynamically assigned pin_sr_data
 	// If any bit of any station is set, the relay is turned on
 	byte isActive = 0;
+	byte bid;
 	if (status.enabled) {
 		for(bid=0;bid<=MAX_EXT_BOARDS;bid++) {
 			isActive |= station_bits[MAX_EXT_BOARDS-bid];

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -872,6 +872,8 @@ void OpenSprinkler::begin() {
 	detect_expanders();
 
 #else
+	// set power supply relay pin to output
+	pinMode(PIN_OSPI_POWER, OUTPUT);
 
 	// shift register setup
 	pinMode(PIN_SR_OE, OUTPUT);
@@ -1194,11 +1196,11 @@ void OpenSprinkler::latch_apply_all_station_bits() {
 }
 #endif
 
-/** Set power supply relais pin */
-void OpenSprinkler::set_power_supply_relais_pin()
+/** Set power supply relay pin */
+void OpenSprinkler::set_power_supply_relay_pin()
 {
 	#if defined(OSPI) // if OSPI, use dynamically assigned pin_sr_data
-	// If any bit of any station is set, the relais is turned on
+	// If any bit of any station is set, the relay is turned on
 	byte isActive = 0;
 	if (status.enabled) {
 		for(bid=0;bid<=MAX_EXT_BOARDS;bid++) {
@@ -1279,8 +1281,8 @@ void OpenSprinkler::apply_all_station_bits() {
 	}
 
 	#if defined(OSPI)
-	// set power supply relais
-	set_power_supply_relais_pin();
+	// set power supply relay
+	set_power_supply_relay_pin();
 	#endif
 
 	#if defined(ARDUINO)

--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -1194,6 +1194,21 @@ void OpenSprinkler::latch_apply_all_station_bits() {
 }
 #endif
 
+/** Set power supply relais pin */
+void OpenSprinkler::set_power_supply_relais_pin()
+{
+	#if defined(OSPI) // if OSPI, use dynamically assigned pin_sr_data
+	// If any bit of any station is set, the relais is turned on
+	byte isActive = 0;
+	if (status.enabled) {
+		for(bid=0;bid<=MAX_EXT_BOARDS;bid++) {
+			isActive |= station_bits[MAX_EXT_BOARDS-bid];
+		}
+	}
+	digitalWrite(PIN_OSPI_POWER, isActive ? 1 : 0);
+	#endif
+}
+
 /** Apply all station bits
  * !!! This will activate/deactivate valves !!!
  */
@@ -1262,6 +1277,11 @@ void OpenSprinkler::apply_all_station_bits() {
 			digitalWrite(PIN_SR_CLOCK, HIGH);
 		}
 	}
+
+	#if defined(OSPI)
+	// set power supply relais
+	set_power_supply_relais_pin();
+	#endif
 
 	#if defined(ARDUINO)
 	if((hw_type==HW_TYPE_DC) && engage_booster) {

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -319,6 +319,7 @@ public:
 	static byte set_station_bit(byte sid, byte value, uint16_t dur=0); // set station bit of one station (sid->station index, value->0/1)
 	static void switch_special_station(byte sid, byte value, uint16_t dur=0); // swtich special station
 	static void clear_all_station_bits(); // clear all station bits
+	static void set_power_supply_relais_pin(); // Set power supply relais pin
 	static void apply_all_station_bits(); // apply all station bits (activate/deactive values)
 
 	static int8_t send_http_request(uint32_t ip4, uint16_t port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=5000);

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -319,7 +319,7 @@ public:
 	static byte set_station_bit(byte sid, byte value, uint16_t dur=0); // set station bit of one station (sid->station index, value->0/1)
 	static void switch_special_station(byte sid, byte value, uint16_t dur=0); // swtich special station
 	static void clear_all_station_bits(); // clear all station bits
-	static void set_power_supply_relais_pin(); // Set power supply relais pin
+	static void set_power_supply_relay_pin(); // Set power supply relay pin
 	static void apply_all_station_bits(); // apply all station bits (activate/deactive values)
 
 	static int8_t send_http_request(uint32_t ip4, uint16_t port, char* p, void(*callback)(char*)=NULL, uint16_t timeout=5000);

--- a/defines.h
+++ b/defines.h
@@ -36,7 +36,7 @@ typedef unsigned long ulong;
 														// if this number is different from the one stored in non-volatile memory
 														// a device reset will be automatically triggered
 
-#define OS_FW_MINOR      11  // Firmware minor version  // original value: 3; -> 11 to test if my version is device
+#define OS_FW_MINOR      3  // Firmware minor version
 
 /** Hardware version base numbers */
 #define OS_HW_VERSION_BASE   0x00 // OpenSprinkler

--- a/defines.h
+++ b/defines.h
@@ -415,6 +415,10 @@ enum {
 	#define PIN_SENSOR1       14
 	#define PIN_SENSOR2       23
 	#define PIN_RFTX          15    // RF transmitter pin
+
+	// defined by Lorenz:
++	#define PIN_OSPI_POWER    24    // set to high if valve is on to enable power supply relais for valves
+
 	//#define PIN_BUTTON_1      23    // button 1
 	//#define PIN_BUTTON_2      24    // button 2
 	//#define PIN_BUTTON_3      25    // button 3

--- a/defines.h
+++ b/defines.h
@@ -36,7 +36,7 @@ typedef unsigned long ulong;
 														// if this number is different from the one stored in non-volatile memory
 														// a device reset will be automatically triggered
 
-#define OS_FW_MINOR      3  // Firmware minor version
+#define OS_FW_MINOR      11  // Firmware minor version  // original value: 3; -> 11 to test if my version is device
 
 /** Hardware version base numbers */
 #define OS_HW_VERSION_BASE   0x00 // OpenSprinkler
@@ -417,7 +417,7 @@ enum {
 	#define PIN_RFTX          15    // RF transmitter pin
 
 	// defined by Lorenz:
-+	#define PIN_OSPI_POWER    24    // set to high if valve is on to enable power supply relais for valves
++	#define PIN_OSPI_POWER    24    // set to high if valve is on to enable power supply relay for valves
 
 	//#define PIN_BUTTON_1      23    // button 1
 	//#define PIN_BUTTON_2      24    // button 2

--- a/defines.h
+++ b/defines.h
@@ -417,7 +417,7 @@ enum {
 	#define PIN_RFTX          15    // RF transmitter pin
 
 	// defined by Lorenz:
-+	#define PIN_OSPI_POWER    24    // set to high if valve is on to enable power supply relay for valves
+	#define PIN_OSPI_POWER    24    // set to high if valve is on to enable power supply relay for valves
 
 	//#define PIN_BUTTON_1      23    // button 1
 	//#define PIN_BUTTON_2      24    // button 2
@@ -457,6 +457,8 @@ enum {
 	#define PIN_RFTX        0
 	#define PIN_FREE_LIST  {}
 	#define ETHER_BUFFER_SIZE   16384
+	// defined by Lorenz:
+	#define PIN_OSPI_POWER    0    // set to high if valve is on to enable power supply relay for valves
 #endif
 
 #if defined(ENABLE_DEBUG) /** Serial debug functions */


### PR DESCRIPTION
The regular power supply has a 24V AC output to run the valves. For most of the time, no valve is active and only the Raspberry Pi is running with 5V. About 70% of power can be saved if a separate 5V power supply is used for the Raspberry Pi and the 24V power supply is switched on by a relay only if a valve is active. This commit activates GPIO 24 (pin 18) when a valve is active in order to switch the relay running the 24V AC power supply.